### PR TITLE
Update ion-md-input.js

### DIFF
--- a/js/ion-md-input.js
+++ b/js/ion-md-input.js
@@ -67,7 +67,7 @@ angular.module('ionMdInput', [])
           if (this.value === '') {
             this.className = mdInput.className.replace(reg, ' ');
           } else {
-            this.classList.toggle(dirtyClass);
+            this.classList.add(dirtyClass);
           }
         };
         // Here we are saying, on 'blur', call toggleClass, on mdInput


### PR DESCRIPTION
Use 'add' instead of 'toggle' to stop the lable droping into input box when it does have a value.
Calling add from classList will not add extra class if it alreay exists.
